### PR TITLE
basic error handling

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">Space Flight News</string>
-    <string name="retry">Retry.</string>
-    <string name="something_went_wrong">Something went wrong. Please try again.</string>
+    <string name="retry">Retry</string>
+    <string name="no_internet">No internet connection. Please check your connection</string>
+    <string name="server_error">Server error. Please try again later</string>
+    <string name="something_went_wrong">Something went wrong. Please try again</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Space Flight News</string>
+    <string name="retry">Retry.</string>
+    <string name="something_went_wrong">Something went wrong. Please try again.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
+import androidx.compose.material3.Button
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
@@ -44,23 +45,28 @@ internal fun ArticleListScreen() {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        ArticleListContent(
-            articles = state.articles,
-        )
+        ArticleListContent(articles = state.articles)
 
-        // Show error message if there's one
         state.error?.let { errorMessage ->
-            Text(
-                text = errorMessage,
-                color = Color.Red,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(16.dp)
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                Text(
+                    text = errorMessage,
+                    color = Color.Red,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(16.dp)
+                )
+
+                Button(onClick = { viewModel.fetchArticles() }) {
+                    Text("Retry")
+                }
+            }
         }
     }
 }
+
 
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -31,7 +31,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
+import spaceflightnews.composeapp.generated.resources.Res
+import spaceflightnews.composeapp.generated.resources.retry
+import spaceflightnews.composeapp.generated.resources.something_went_wrong
 
 @Composable
 internal fun ArticleListScreen() {
@@ -50,26 +54,24 @@ internal fun ArticleListScreen() {
             }
 
             is ArticleListViewState.Error -> {
-                val error = (state as ArticleListViewState.Error).message ?: "Unknown error"
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.align(Alignment.Center)
                 ) {
                     Text(
-                        text = error,
+                        text = stringResource(Res.string.something_went_wrong),
                         color = Color.Red,
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(16.dp)
                     )
                     Button(onClick = { viewModel.fetchArticles() }) {
-                        Text("Retry")
+                        Text(text = stringResource(Res.string.retry))
                     }
                 }
             }
         }
     }
 }
-
 
 @Composable
 private fun ArticleListContent(

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -1,6 +1,7 @@
 package com.landomen.spaceflightnews.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
@@ -14,18 +15,27 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import coil3.compose.AsyncImage
 import com.landomen.spaceflightnews.model.Article
+import com.landomen.spaceflightnews.network.ApiService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toLocalDateTime
+import kotlinx.io.IOException
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -33,10 +43,25 @@ internal fun ArticleListScreen() {
     val viewModel = koinViewModel<ArticleListViewModel>()
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    ArticleListContent(
-        articles = state.articles,
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        ArticleListContent(
+            articles = state.articles,
+        )
+
+        // Show error message if there's one
+        state.error?.let { errorMessage ->
+            Text(
+                text = errorMessage,
+                color = Color.Red,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(16.dp)
+            )
+        }
+    }
 }
+
 
 @Composable
 private fun ArticleListContent(

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -34,7 +34,9 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import spaceflightnews.composeapp.generated.resources.Res
+import spaceflightnews.composeapp.generated.resources.no_internet
 import spaceflightnews.composeapp.generated.resources.retry
+import spaceflightnews.composeapp.generated.resources.server_error
 import spaceflightnews.composeapp.generated.resources.something_went_wrong
 
 @Composable
@@ -43,7 +45,7 @@ internal fun ArticleListScreen() {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        when (state) {
+        when (val currentState = state) {
             is ArticleListViewState.Loading -> {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
@@ -54,12 +56,18 @@ internal fun ArticleListScreen() {
             }
 
             is ArticleListViewState.Error -> {
+                val errorMessage = when (currentState.errorType) {
+                    ErrorType.NoInternet -> stringResource(Res.string.no_internet)
+                    ErrorType.ServerError -> stringResource(Res.string.server_error)
+                    ErrorType.Unknown -> stringResource(Res.string.something_went_wrong)
+                }
+
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.align(Alignment.Center)
                 ) {
                     Text(
-                        text = stringResource(Res.string.something_went_wrong),
+                        text = errorMessage,
                         color = Color.Red,
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.padding(16.dp)

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -26,6 +26,7 @@ import coil3.compose.AsyncImage
 import com.landomen.spaceflightnews.model.Article
 import kotlinx.datetime.LocalDateTime
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
@@ -38,28 +39,36 @@ internal fun ArticleListScreen() {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        ArticleListContent(articles = state.articles)
+        when (state) {
+            is ArticleListViewState.Loading -> {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
 
-        state.error?.let { errorMessage ->
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.align(Alignment.Center)
-            ) {
-                Text(
-                    text = errorMessage,
-                    color = Color.Red,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(16.dp)
-                )
+            is ArticleListViewState.Success -> {
+                val articles = (state as ArticleListViewState.Success).articles
+                ArticleListContent(articles = articles)
+            }
 
-                Button(onClick = { viewModel.fetchArticles() }) {
-                    Text("Retry")
+            is ArticleListViewState.Error -> {
+                val error = (state as ArticleListViewState.Error).message ?: "Unknown error"
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    Text(
+                        text = error,
+                        color = Color.Red,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                    Button(onClick = { viewModel.fetchArticles() }) {
+                        Text("Retry")
+                    }
                 }
             }
         }
     }
 }
-
 
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -51,7 +51,7 @@ internal fun ArticleListScreen() {
             }
 
             is ArticleListViewState.Success -> {
-                val articles = (state as ArticleListViewState.Success).articles
+                val articles = currentState.articles
                 ArticleListContent(articles = articles)
             }
 

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListScreen.kt
@@ -21,22 +21,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewModelScope
 import coil3.compose.AsyncImage
 import com.landomen.spaceflightnews.model.Article
-import com.landomen.spaceflightnews.network.ApiService
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
 import androidx.compose.material3.Button
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toLocalDateTime
-import kotlinx.io.IOException
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
@@ -14,8 +14,13 @@ class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
     val state: StateFlow<ArticleListViewState> = _state
 
     init {
+        fetchArticles()
+    }
+
+    fun fetchArticles() {
         viewModelScope.launch {
             try {
+                _state.value = _state.value.copy(error = null) // Clear previous error
                 val articles = apiService.getArticles()
                 _state.value = _state.value.copy(
                     articles = articles.filter { it.imageUrl.isNotEmpty() }
@@ -28,6 +33,7 @@ class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
         }
     }
 }
+
 
 
 data class ArticleListViewState(

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
@@ -2,6 +2,7 @@ package com.landomen.spaceflightnews.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import coil3.network.HttpException
 import com.landomen.spaceflightnews.model.Article
 import com.landomen.spaceflightnews.network.ApiService
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,18 +26,25 @@ class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
                     .filter { it.imageUrl.isNotEmpty() }
                 _state.value = ArticleListViewState.Success(articles)
             } catch (e: IOException) {
-                _state.value = ArticleListViewState.Error(e.message)
+                _state.value = ArticleListViewState.Error(ErrorType.NoInternet)
+            } catch (e: HttpException) {
+                _state.value = ArticleListViewState.Error(ErrorType.ServerError)
             } catch (e: Exception) {
-                _state.value = ArticleListViewState.Error(e.message)
+                _state.value = ArticleListViewState.Error(ErrorType.Unknown)
             }
         }
     }
+
 }
-
-
 
 sealed interface ArticleListViewState {
     data object Loading : ArticleListViewState
     data class Success(val articles: List<Article> = emptyList()) : ArticleListViewState
-    data class Error(val message: String? = null) : ArticleListViewState
+    data class Error(val errorType: ErrorType) : ArticleListViewState
+}
+
+sealed class ErrorType {
+    data object NoInternet : ErrorType()
+    data object ServerError : ErrorType()
+    data object Unknown : ErrorType()
 }

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
@@ -7,19 +7,30 @@ import com.landomen.spaceflightnews.network.ApiService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.io.IOException
 
-class ArticleListViewModel(private val apiService: ApiService) : ViewModel(){
+class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
     private val _state = MutableStateFlow(ArticleListViewState())
     val state: StateFlow<ArticleListViewState> = _state
 
     init {
         viewModelScope.launch {
-            val articles = apiService.getArticles()
-            _state.value = _state.value.copy(articles = articles.filter { !it.imageUrl.isEmpty() })
+            try {
+                val articles = apiService.getArticles()
+                _state.value = _state.value.copy(
+                    articles = articles.filter { it.imageUrl.isNotEmpty() }
+                )
+            } catch (e: IOException) {
+                _state.value = _state.value.copy(error = "No internet connection.")
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(error = "Something went wrong.")
+            }
         }
     }
 }
 
+
 data class ArticleListViewState(
     val articles: List<Article> = emptyList(),
+    val error: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
@@ -25,13 +25,14 @@ class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
                     .filter { it.imageUrl.isNotEmpty() }
                 _state.value = ArticleListViewState.Success(articles)
             } catch (e: IOException) {
-                _state.value = ArticleListViewState.Error("No internet connection.")
+                _state.value = ArticleListViewState.Error(e.message)
             } catch (e: Exception) {
-                _state.value = ArticleListViewState.Error("Something went wrong.")
+                _state.value = ArticleListViewState.Error(e.message)
             }
         }
     }
 }
+
 
 
 sealed interface ArticleListViewState {

--- a/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/landomen/spaceflightnews/ui/ArticleListViewModel.kt
@@ -25,11 +25,11 @@ class ArticleListViewModel(private val apiService: ApiService) : ViewModel() {
                 val articles = apiService.getArticles()
                     .filter { it.imageUrl.isNotEmpty() }
                 _state.value = ArticleListViewState.Success(articles)
-            } catch (e: IOException) {
+            } catch (_: IOException) {
                 _state.value = ArticleListViewState.Error(ErrorType.NoInternet)
-            } catch (e: HttpException) {
+            } catch (_: HttpException) {
                 _state.value = ArticleListViewState.Error(ErrorType.ServerError)
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 _state.value = ArticleListViewState.Error(ErrorType.Unknown)
             }
         }


### PR DESCRIPTION
hi @landomen 

I've noticed that the app currently crashes on launch when there is no internet connection. This PR introduces basic error handling in the `ArticleListViewModel` to prevent the crash and provide a fallback UI message to the user.

**Changes**
Wrapped the API call in a try-catch block to handle IOException (no internet) and other exceptions.

Extended `ArticleListViewState` to include an error: String? property.

Updated the `ArticleListScreen` UI to display an error message ("No internet connection.") when applicable.

**NB:**

Tested on Android only — iOS was not tested yet, as this is an early-stage app (looking forward for the offline support with SQL delight btw >>)